### PR TITLE
Fix issue #1 & #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,8 @@
-FROM open-liberty
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+#FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 
-# Use this if WebSphere Liberty is desired.
-# FROM websphere-liberty
-
-# Tell Liberty not to generate a default keystore.
-ENV KEYSTORE_REQUIRED "false"
-
-# Define build variables which will be passed in during image building time.
-ARG keyStoreName
-ARG keyStorePassword
-
-# Copy user supplied keystore.
-COPY --chown=1001:0 ${keyStoreName} /config/resources/security/
-
-# Import the custom keystore into Java CA certificates to 
-# enable REST invocations within the application over SSL.
-USER root
-RUN  $JAVA_HOME/bin/keytool -importkeystore -noprompt \
-    -srckeystore /config/resources/security/${keyStoreName} \
-    -srcstorepass ${keyStorePassword} \
-    -destkeystore $JAVA_HOME/lib/security/cacerts \
-    -deststorepass changeit
-USER 1001
-
-# Copy deployment artifacts.
 COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
-COPY --chown=1001:0 server.xml /config/
+COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/
 COPY --chown=1001:0 javaee-cafe/target/javaee-cafe.war /config/apps/
+
+RUN configure.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
-#FROM openliberty/open-liberty:kernel-java11-openj9-ubi
+# both java8 & java11 images are supported
+# comment line 3 and uncomment line 4 to build application image from image with java11
+#FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources
 COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/
 COPY --chown=1001:0 javaee-cafe/target/javaee-cafe.war /config/apps/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 #FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources
+COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
 COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/
 COPY --chown=1001:0 javaee-cafe/target/javaee-cafe.war /config/apps/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # both java8 & java11 images are supported
-# comment line 3 and uncomment line 4 to build application image from image with java11
+# comment line 3 and uncomment line 4 to build the application image with java11
 FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 #FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # both java8 & java11 images are supported
 # comment line 3 and uncomment line 4 to build application image from image with java11
-#FROM openliberty/open-liberty:kernel-java8-openj9-ubi
-FROM openliberty/open-liberty:kernel-java11-openj9-ubi
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+#FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 
 COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources
 COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/

--- a/Dockerfile-wlp
+++ b/Dockerfile-wlp
@@ -1,5 +1,5 @@
 # both java8 & java11 images are supported
-# comment line 3 and uncomment line 4 to build application image from image with java11
+# comment line 3 and uncomment line 4 to build the application image with java11
 FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 #FROM ibmcom/websphere-liberty:kernel-java11-openj9-ubi
 

--- a/Dockerfile-wlp
+++ b/Dockerfile-wlp
@@ -1,0 +1,10 @@
+# both java8 & java11 images are supported
+# comment line 3 and uncomment line 4 to build application image from image with java11
+FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
+#FROM ibmcom/websphere-liberty:kernel-java11-openj9-ubi
+
+COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources
+COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/
+COPY --chown=1001:0 javaee-cafe/target/javaee-cafe.war /config/apps/
+
+RUN configure.sh

--- a/Dockerfile-wlp
+++ b/Dockerfile-wlp
@@ -3,7 +3,7 @@
 FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 #FROM ibmcom/websphere-liberty:kernel-java11-openj9-ubi
 
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources
+COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
 COPY --chown=1001:0 javaee-cafe/src/main/liberty/config/server.xml /config/
 COPY --chown=1001:0 javaee-cafe/target/javaee-cafe.war /config/apps/
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also get the application up and running using `mvn` command.
 * [Configuring an OpenID Connect Client in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_config_oidc_rp.html)
 * [Enabling SSL communication in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_ssl.html)
 * [Configuring authorization for applications in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_rolebased.html)
-* [keytool](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html)
+* [SSL configuration in Open Liberty](https://openliberty.io/docs/ref/config/#ssl.html)
 
 ## Future Considerations
 * Applying JWT propagated from the inital login to secure internal REST calls.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now we can get the application up and running.  The following steps show two dif
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 
 ### Start the Application with Maven
-You can also get the application up and running using `mvn` command.
+You can also get the application up and running using the `mvn` command.
 * Open a console. Navigate to where you have this repository downloaded on your local machine.
 * Run `mvn clean package --file javaee-cafe/pom.xml`.
 * Execute the following command with required parameters (Windows PowerShell uses a slight variant):

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Now we can get the application up and running.  The following steps show two dif
 You can also get the application up and running using `mvn` command.
 * Open a console. Navigate to where you have this repository downloaded on your local machine.
 * Run `mvn clean package --file javaee-cafe/pom.xml`.
-* Execute the following command with required parameters (do not use this command for Windows PowerShell):
+* Execute the following command with required parameters (Windows PowerShell uses a slight variant):
   * `postgresql.server.name`: Use `localhost`.
   * `postgresql.user`: Use `postgres`.
   * `postgresql.password`: Keep it empty.

--- a/README.md
+++ b/README.md
@@ -32,19 +32,11 @@ The next step is to get the application up and running. Follow the steps below t
 * Change directory to `<path-to-repository>/javaee-cafe`.
 * Run `mvn clean package`. This will generate a war deployment under `./target`.
 * Change directory back to `<path-to-repository>`.
-* You will need to create a custom key store for SSL. Issue the following command to do so. Please use the same password for the key store and key.
+* Build a Docker image tagged `javaee-cafe` by running the following command.
   ```
-  keytool -genkeypair -keyalg RSA -storetype jks -keystore key.jks
-  ```
-* Build a Docker image tagged `javaee-cafe` by running the following command. These are the parameters required:
-  * `keyStoreName`: key.jks from above.
-  * `keyStorePassword`: The key store password from above.
-  ```
-  docker build -t javaee-cafe --build-arg keyStoreName=key.jks --build-arg keyStorePassword=<...> .
+  docker build -t javaee-cafe .
   ```
 * To run the newly built image, execute the following command. These are the parameters required:
-  * `KEYSTORE_NAME`: key.jks from above.
-  * `KEYSTORE_PASSWORD`: The key store password from above.
   * `POSTGRESQL_SERVER_NAME`: For Mac and Windows users, 'host.docker.internal' may be used. For other operating systems, use the IP 172.17.0.2 (note, this depends on the fact that the database is the first container to start).
   * `POSTGRESQL_USER`: Use `postgres`.
   * `POSTGRESQL_PASSWORD`: Keep it empty.
@@ -52,7 +44,7 @@ The next step is to get the application up and running. Follow the steps below t
   * `CLIENT_SECRET`: The client secret value you noted down.
   * `TENANT_ID`: The tenant/directory ID you noted down.
   ```
-  docker run -it --rm -p 9080:9080 -p 9443:9443 -e KEYSTORE_NAME=key.jks -e KEYSTORE_PASSWORD=<...> -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD="" -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
+  docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD="" -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 * Once the application starts, you can visit the JSF client at

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ The first step to getting the application running is getting the database up. Pl
   ```
 * The database is now ready (to stop it, simply press Control-C after the Java EE application is shutdown).
 
+Now we can get the application up and running.  The following steps show two diferent ways to do so: Docker and maven.
+
 ### Start the Application with Docker
-The next step is to get the application up and running. Follow the steps below to do so.
+
 * Open a console. Navigate to where you have this repository downloaded on your local machine.
 * Run `mvn clean package --file javaee-cafe/pom.xml`. This will generate a war deployment under `./javaee-cafe/target`.
 * Build a Docker image tagged `javaee-cafe` by running one of the following commands.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Now we can get the application up and running.  The following steps show two dif
 * Build a Docker image tagged `javaee-cafe` by running one of the following commands.
   ```
   # build from open liberty base image
-  docker build -t javaee-cafe .
+  docker build -t javaee-cafe --pull .
   # build from websphere liberty base iamge
-  docker build -t javaee-cafe --file=Dockerfile-wlp .
+  docker build -t javaee-cafe --pull --file=Dockerfile-wlp .
   ```
 * To run the newly built image, execute the following command. These are the parameters required:
   * `POSTGRESQL_SERVER_NAME`: For Mac and Windows users, 'host.docker.internal' may be used. For other operating systems, use the IP 172.17.0.2 (note, this depends on the fact that the database is the first container to start).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also get the application up and running using `mvn` command.
   ```
 * Note: if you want to run from Windows PowerShell, please use the following command:
   ```
-  mvn "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" liberty:run --file javaee-cafe/pom.xml
+  mvn --file javaee-cafe/pom.xml liberty:run "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" 
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This project demonstrates how to secure your Java EE application on Open Liberty/WebSphere Liberty using Azure Active Directory and OpenID Connect. The following is how you run the demo.
 
 ## Prerequisites
-* Install Java SE 8 (we used [AdoptOpenJDK OpenJDK 8 LTS/HotSpot](https://adoptopenjdk.net)).
+* Install Java SE 8 (we used [AdoptOpenJDK OpenJDK 8 LTS/OpenJ9](https://adoptopenjdk.net)).
 * Install [Maven](https://maven.apache.org/download.cgi).
 * Install [Docker](https://docs.docker.com/get-docker/) for your OS.
 * You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/en-us/free).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The next step is to get the application up and running. Follow the steps below t
   * `CLIENT_SECRET`: The client secret value you noted down.
   * `TENANT_ID`: The tenant/directory ID you noted down.
   ```
-  docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD="" -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
+  docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD= -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 
@@ -61,7 +61,11 @@ You can also get the application up and running using `mvn` command.
   * `client.secret`: The client secret value you noted down.
   * `tenant.id`: The tenant/directory ID you noted down.
   ```
-  mvn -Dpostgresql.server.name=<...> -Dpostgresql.user=<...> -Dpostgresql.password="" -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
+  mvn -Dpostgresql.server.name=<...> -Dpostgresql.user=<...> -Dpostgresql.password= -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
+  ```
+* Note: if you want to run from Windwos PowerShell, using the following command:
+  ```
+  mvn "-Dpostgresql.server.name=<...>" "-Dpostgresql.user=<...>" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" liberty:run --file javaee-cafe/pom.xml
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Now we can get the application up and running.  The following steps show two dif
 You can also get the application up and running using `mvn` command.
 * Open a console. Navigate to where you have this repository downloaded on your local machine.
 * Run `mvn clean package --file javaee-cafe/pom.xml`.
-* Execute the following command with required parameters:
+* Execute the following command with required parameters (do not use this command for Windows PowerShell):
   * `postgresql.server.name`: Use `localhost`.
   * `postgresql.user`: Use `postgres`.
   * `postgresql.password`: Keep it empty.
@@ -65,7 +65,7 @@ You can also get the application up and running using `mvn` command.
   ```
   mvn -Dpostgresql.server.name=localhost -Dpostgresql.user=postgres -Dpostgresql.password= -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
   ```
-* Note: if you want to run from Windows PowerShell, using the following command:
+* Note: if you want to run from Windows PowerShell, please use the following command:
   ```
   mvn "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" liberty:run --file javaee-cafe/pom.xml
   ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also get the application up and running using `mvn` command.
   ```
   mvn -Dpostgresql.server.name=localhost -Dpostgresql.user=postgres -Dpostgresql.password= -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
   ```
-* Note: if you want to run from Windwos PowerShell, using the following command:
+* Note: if you want to run from Windows PowerShell, using the following command:
   ```
   mvn "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" liberty:run --file javaee-cafe/pom.xml
   ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also get the application up and running using `mvn` command.
   * `client.secret`: The client secret value you noted down.
   * `tenant.id`: The tenant/directory ID you noted down.
   ```
-  mvn -Dpostgresql.server.name=<...> -Dpostgresql.user=<...> -Dpostgresql.password="" -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
+  mvn -Dpostgresql.server.name=localhost -Dpostgresql.user=postgres -Dpostgresql.password="" -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ The first step to getting the application running is getting the database up. Pl
 ### Start the Application with Docker
 The next step is to get the application up and running. Follow the steps below to do so.
 * Open a console. Navigate to where you have this repository downloaded on your local machine.
-* Change directory to `<path-to-repository>/javaee-cafe`.
-* Run `mvn clean package`. This will generate a war deployment under `./target`.
-* Change directory back to `<path-to-repository>`.
-* Build a Docker image tagged `javaee-cafe` by running the following command.
+* Run `mvn clean package --file javaee-cafe/pom.xml`. This will generate a war deployment under `./javaee-cafe/target`.
+* Build a Docker image tagged `javaee-cafe` by running one of the following commands.
   ```
+  # build from open liberty base image
   docker build -t javaee-cafe .
+  # build from websphere liberty base iamge
+  docker build -t javaee-cafe --file=Dockerfile-wlp .
   ```
 * To run the newly built image, execute the following command. These are the parameters required:
   * `POSTGRESQL_SERVER_NAME`: For Mac and Windows users, 'host.docker.internal' may be used. For other operating systems, use the IP 172.17.0.2 (note, this depends on the fact that the database is the first container to start).
@@ -47,6 +48,24 @@ The next step is to get the application up and running. Follow the steps below t
   docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD="" -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
   ```
 * Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
+
+### Start the Application with Maven
+You can also get the application up and running using `mvn` command.
+* Open a console. Navigate to where you have this repository downloaded on your local machine.
+* Run `mvn clean package --file javaee-cafe/pom.xml`.
+* Execute the following command with required parameters:
+  * `postgresql.server.name`: Use `localhost`.
+  * `postgresql.user`: Use `postgres`.
+  * `postgresql.password`: Keep it empty.
+  * `client.id`: The application/client ID you noted down.
+  * `client.secret`: The client secret value you noted down.
+  * `tenant.id`: The tenant/directory ID you noted down.
+  ```
+  mvn -Dpostgresql.server.name=<...> -Dpostgresql.user=<...> -Dpostgresql.password="" -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
+  ```
+* Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
+
+### Visit the Application
 * Once the application starts, you can visit the JSF client at
   * [https://localhost:9443/javaee-cafe](https://localhost:9443/javaee-cafe)
   * [http://localhost:9080/javaee-cafe](http://localhost:9080/javaee-cafe)

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -10,34 +10,34 @@
 	<name>${project.artifactId}</name>
 	<description>This is the basic Java EE application used in the demo.
         It is a simple CRUD application. It uses Maven and Java EE 8 (JAX-RS, EJB, CDI, JPA, JSON-B, JSF, Bean Validation).
-    </description>
+  </description>
 	<properties>
-		<javaee.api.version>8.0</javaee.api.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<failOnMissingWebXml>false</failOnMissingWebXml>
-		<openliberty.version>[20.0.0.1,)</openliberty.version>
-		<openliberty.maven.version>3.2</openliberty.maven.version>
+    <javaee.api.version>8.0</javaee.api.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <openliberty.version>[20.0.0.1,)</openliberty.version>
+    <openliberty.maven.version>3.2</openliberty.maven.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>${javaee.api.version}</version>
-			<scope>provided</scope>
+  <dependencies>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>${javaee.api.version}</version>
+      <scope>provided</scope>
     </dependency>
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
-			<scope>provided</scope>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
     </dependency>
 	</dependencies>
-	<build>
-		<finalName>${project.artifactId}</finalName>
-	</build>
-	<profiles>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+  <profiles>
     <profile>
       <id>liberty</id>
       <activation>

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -26,13 +26,13 @@
 			<artifactId>javaee-api</artifactId>
 			<version>${javaee.api.version}</version>
 			<scope>provided</scope>
-        </dependency>
+    </dependency>
 		<dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
 			<scope>provided</scope>
-        </dependency>
+    </dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -14,6 +14,11 @@
 	<properties>
 		<javaee.api.version>8.0</javaee.api.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<failOnMissingWebXml>false</failOnMissingWebXml>
+		<openliberty.version>[20.0.0.1,)</openliberty.version>
+		<openliberty.maven.version>3.2</openliberty.maven.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -21,28 +26,50 @@
 			<artifactId>javaee-api</artifactId>
 			<version>${javaee.api.version}</version>
 			<scope>provided</scope>
-		</dependency>
+        </dependency>
+		<dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+			<scope>provided</scope>
+        </dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-				<inherited>true</inherited>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>3.2.2</version>
-				<configuration>
-					<failOnMissingWebXml>false</failOnMissingWebXml>
-				</configuration>
-			</plugin>
-		</plugins>
 	</build>
+	<profiles>
+    <profile>
+      <id>liberty</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.openliberty.tools</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>${openliberty.maven.version}</version>
+            <executions>
+              <execution>
+                <id>package-server</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>create</goal>
+                  <goal>install-feature</goal>
+                  <goal>deploy</goal>
+                  <goal>package</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/wlp-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+            <configuration>
+              <include>runnable</include>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -8,10 +8,10 @@
 	<version>0.1-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>${project.artifactId}</name>
-	<description>This is the basic Java EE application used in the demo.
+  <description>This is the basic Java EE application used in the demo.
         It is a simple CRUD application. It uses Maven and Java EE 8 (JAX-RS, EJB, CDI, JPA, JSON-B, JSF, Bean Validation).
   </description>
-	<properties>
+  <properties>
     <javaee.api.version>8.0</javaee.api.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -19,7 +19,7 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <openliberty.version>[20.0.0.1,)</openliberty.version>
     <openliberty.maven.version>3.2</openliberty.maven.version>
-	</properties>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>javax</groupId>
@@ -33,7 +33,7 @@
       <version>2.3.1</version>
       <scope>provided</scope>
     </dependency>
-	</dependencies>
+  </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>
   </build>

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<artifactId>javaee-cafe</artifactId>
-	<groupId>javaee-cafe</groupId>
-	<version>0.1-SNAPSHOT</version>
-	<packaging>war</packaging>
-	<name>${project.artifactId}</name>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>javaee-cafe</artifactId>
+  <groupId>javaee-cafe</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <name>${project.artifactId}</name>
   <description>This is the basic Java EE application used in the demo.
-        It is a simple CRUD application. It uses Maven and Java EE 8 (JAX-RS, EJB, CDI, JPA, JSON-B, JSF, Bean Validation).
+    It is a simple CRUD application. It uses Maven and Java EE 8 (JAX-RS, EJB, CDI, JPA, JSON-B, JSF, Bean Validation).
   </description>
   <properties>
     <javaee.api.version>8.0</javaee.api.version>
@@ -19,6 +19,12 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <openliberty.version>[20.0.0.1,)</openliberty.version>
     <openliberty.maven.version>3.2</openliberty.maven.version>
+    <postgresql.server.name></postgresql.server.name>
+    <postgresql.user></postgresql.user>
+    <postgresql.password></postgresql.password>
+    <client.id></client.id>
+    <client.secret></client.secret>
+    <tenant.id></tenant.id>
   </properties>
   <dependencies>
     <dependency>
@@ -32,6 +38,12 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.4</version>
+      <type>jar</type>
     </dependency>
   </dependencies>
   <build>
@@ -61,6 +73,14 @@
                 </goals>
                 <configuration>
                   <outputDirectory>target/wlp-package</outputDirectory>
+                  <bootstrapProperties>
+                    <postgresql.server.name>${postgresql.server.name}</postgresql.server.name>
+                    <postgresql.user>${postgresql.user}</postgresql.user>
+                    <postgresql.password>${postgresql.password}</postgresql.password>
+                    <client.id>${client.id}</client.id>
+                    <client.secret>${client.secret}</client.secret>
+                    <tenant.id>${tenant.id}</tenant.id>
+                  </bootstrapProperties>
                 </configuration>
               </execution>
             </executions>
@@ -68,6 +88,24 @@
               <include>runnable</include>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.1.2</version>
+            <executions>
+              <execution>
+                <id>copy-postgresql-driver</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeArtifactIds>postgresql</includeArtifactIds>
+                  <outputDirectory>${project.build.directory}/liberty/wlp/usr/shared/resources</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>          
         </plugins>
       </build>
     </profile>

--- a/javaee-cafe/src/main/liberty/config/server.xml
+++ b/javaee-cafe/src/main/liberty/config/server.xml
@@ -18,9 +18,9 @@
 	<ssl id="defaultSSLConfig"  trustDefaultCerts="true" />
 
 	<openidConnectClient
-		id="liberty-aad-oidc-javaeecafe" clientId="${CLIENT_ID}"
-		clientSecret="${CLIENT_SECRET}"
-		discoveryEndpointUrl="https://login.microsoftonline.com/${TENANT_ID}/v2.0/.well-known/openid-configuration"
+		id="liberty-aad-oidc-javaeecafe" clientId="${client.id}"
+		clientSecret="${client.secret}"
+		discoveryEndpointUrl="https://login.microsoftonline.com/${tenant.id}/v2.0/.well-known/openid-configuration"
 		signatureAlgorithm="RS256"
 		userIdentityToCreateSubject="preferred_username"
 		inboundPropagation="supported" />
@@ -35,8 +35,8 @@
 		jdbcDriverRef="postgresql-driver" jndiName="jdbc/JavaEECafeDB"
 		transactional="true" type="javax.sql.ConnectionPoolDataSource">
 		<properties databaseName="postgres" portNumber="5432"
-			serverName="${POSTGRESQL_SERVER_NAME}" user="${POSTGRESQL_USER}"
-			password="${POSTGRESQL_PASSWORD}" />
+			serverName="${postgresql.server.name}" user="${postgresql.user}"
+			password="${postgresql.password}" />
 	</dataSource>
 
 	<jdbcDriver id="postgresql-driver"
@@ -45,7 +45,7 @@
 		libraryRef="postgresql-library" />
 
 	<library id="postgresql-library">
-		<fileset dir="/opt/ibm/wlp/usr/shared/resources/"
+		<fileset dir="${shared.resource.dir}"
 			id="PostgreSQLFileset" includes="postgresql-42.2.4.jar" />
 	</library>
 

--- a/javaee-cafe/src/main/liberty/config/server.xml
+++ b/javaee-cafe/src/main/liberty/config/server.xml
@@ -3,25 +3,19 @@
 
 	<!-- Enable features -->
 	<featureManager>
-		<feature>javaee-8.0</feature>
+		<feature>cdi-2.0</feature>
+		<feature>jaxb-2.2</feature>
+		<feature>jpa-2.2</feature>
+		<feature>jsf-2.3</feature>
+		<feature>jaxrs-2.1</feature>
+		<feature>ejbLite-3.2</feature>
 		<feature>openidConnectClient-1.0</feature>
 		<feature>transportSecurity-1.0</feature>
-		<feature>appSecurity-2.0</feature>
+		<feature>appSecurity-3.0</feature>
 	</featureManager>
 
-	<!-- A custom key store is user supplied and used for SSL. Java CA certificates 
-		are used as the default trust store (Microsoft is a registered CA and the 
-		Microsoft certificate is used for Azure Active Directory). Because there 
-		are REST invocations within the application via SSL, the custom key store 
-		must be imported to the trust store. See the Dockerfile for more information. -->
-	<ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore"
-		trustStoreRef="defaultTrustStore" />
-	<keyStore id="defaultKeyStore"
-		location="${server.config.dir}/resources/security/${KEYSTORE_NAME}"
-		type="JKS" password="${KEYSTORE_PASSWORD}" />
-	<keyStore id="defaultTrustStore"
-		location="${JAVA_HOME}/lib/security/cacerts" type="JKS"
-		password="changeit" />
+	<!-- trust JDK’s default truststore -->
+	<ssl id="defaultSSLConfig"  trustDefaultCerts="true" />
 
 	<openidConnectClient
 		id="liberty-aad-oidc-javaeecafe" clientId="${CLIENT_ID}"


### PR DESCRIPTION
Change summary:
- Enable running application in local using `mvn` command
  - add `liberty-maven-plugin` to facilitate application deployment & running in local;
  - download posgresql driver as a dependency and copy to ${shared.resource.dir} at packaging pahse;
- Add dependency `jaxb-api` which is removed from java11 so it can support java11 as well
- Verified that both `kernel-java8-openj9-ubi` & `kernel-java11-openj9-ubi` are supported for both open-liberty and websphere-liberty
- Remove process of manually importing self-signed certificate to JVM default trusted keystore and relevant configurations from `Dockerfile` & `server.xml` by specifying property `trustDefaultCerts="true"` in `server.xml`
- update `README.md`