### PR TITLE
Secure rest endpoints using rbac of jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now we can get the application up and running.  The following steps show two dif
   ```
   docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD= -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
   ```
-* Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
+* Wait for Liberty to start and the application to deploy successfully (to stop the application and Liberty, simply press Control-C).
 
 ### Start the Application with Maven
 You can also get the application up and running using the `mvn` command.
@@ -69,7 +69,7 @@ You can also get the application up and running using the `mvn` command.
   ```
   mvn --file javaee-cafe/pom.xml liberty:run "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" 
   ```
-* Wait for Liberty to start and the application to deploy sucessfully (to stop the application and Liberty, simply press Control-C).
+* Wait for Liberty to start and the application to deploy successfully (to stop the application and Liberty, simply press Control-C).
 
 ### Visit the Application
 * Once the application starts, you can visit the JSF client at

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This project demonstrates how to secure your Java EE application on Open Liberty
 ## Setup Azure Active Directory
 * You will first need to [get an Azure Active Directory tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant). It is very likely your Azure account already has a tenant. Please note down your tenant/directory ID.
 * Although this isn't absolutely necessary, you can [create a few Azure Active Directory users](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/add-users-azure-active-directory). You can use these accounts or your own to test the application. Do note down email addresses and passwords for login.
+* You need to create a group as admin group to test RBAC (role-based-access-control) functionality. Follow [create a basic group and add members using Azure Active Directory](https://docs.microsoft.com/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal) to create a group with type as **Security** and add one or more members. Note down group ID.
 * You will need to [create a new application registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in Azure Active Directory. Please specify the redirect URI to be: https://localhost:9443/oidcclient/redirect/liberty-aad-oidc-javaeecafe. Please note down the application (client) ID.
-* You will need to create a new client secret. In the newly created application registration, find 'Certificates & secrets'. Select 'New client secret'. Provide a desciption and hit 'Add'. Note down the generated client secret value.
+* You will need to create a new client secret. In the newly created application registration, find 'Certificates & secrets'. Select 'New client secret'. Provide a description and hit 'Add'. Note down the generated client secret value.
 
 ## Start the Database instance
 The first step to getting the application running is getting the database up. Please follow the instructions below to get the database running.
@@ -26,7 +27,7 @@ The first step to getting the application running is getting the database up. Pl
   ```
 * The database is now ready (to stop it, simply press Control-C after the Java EE application is shutdown).
 
-Now we can get the application up and running.  The following steps show two diferent ways to do so: Docker and maven.
+Now we can get the application up and running.  The following steps show two different ways to do so: Docker and maven.
 
 ### Start the Application with Docker
 
@@ -36,7 +37,7 @@ Now we can get the application up and running.  The following steps show two dif
   ```
   # build from open liberty base image
   docker build -t javaee-cafe --pull .
-  # build from websphere liberty base iamge
+  # build from websphere liberty base image
   docker build -t javaee-cafe --pull --file=Dockerfile-wlp .
   ```
 * To run the newly built image, execute the following command. These are the parameters required:
@@ -46,8 +47,9 @@ Now we can get the application up and running.  The following steps show two dif
   * `CLIENT_ID`: The application/client ID you noted down.
   * `CLIENT_SECRET`: The client secret value you noted down.
   * `TENANT_ID`: The tenant/directory ID you noted down.
+  * `ADMIN_GROUP_ID`: The admin group ID you noted down.
   ```
-  docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD= -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> javaee-cafe
+  docker run -it --rm -p 9080:9080 -p 9443:9443 -e POSTGRESQL_SERVER_NAME=<...> -e POSTGRESQL_USER=postgres -e POSTGRESQL_PASSWORD= -e CLIENT_ID=<...> -e CLIENT_SECRET=<...> -e TENANT_ID=<...> -e ADMIN_GROUP_ID=<...> javaee-cafe
   ```
 * Wait for Liberty to start and the application to deploy successfully (to stop the application and Liberty, simply press Control-C).
 
@@ -62,12 +64,13 @@ You can also get the application up and running using the `mvn` command.
   * `client.id`: The application/client ID you noted down.
   * `client.secret`: The client secret value you noted down.
   * `tenant.id`: The tenant/directory ID you noted down.
+  * `admin.group.id`: The admin group ID you noted down.
   ```
-  mvn -Dpostgresql.server.name=localhost -Dpostgresql.user=postgres -Dpostgresql.password= -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> liberty:run --file javaee-cafe/pom.xml
+  mvn -Dpostgresql.server.name=localhost -Dpostgresql.user=postgres -Dpostgresql.password= -Dclient.id=<...> -Dclient.secret=<...> -Dtenant.id=<...> -Dadmin.group.id=<...> liberty:run --file javaee-cafe/pom.xml
   ```
 * Note: if you want to run from Windows PowerShell, please use the following command:
   ```
-  mvn --file javaee-cafe/pom.xml liberty:run "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" 
+  mvn --file javaee-cafe/pom.xml liberty:run "-Dpostgresql.server.name=localhost" "-Dpostgresql.user=postgres" "-Dpostgresql.password=" "-Dclient.id=<...>" "-Dclient.secret=<...>" "-Dtenant.id=<...>" "-Dadmin.group.id=<...>"
   ```
 * Wait for Liberty to start and the application to deploy successfully (to stop the application and Liberty, simply press Control-C).
 
@@ -75,12 +78,13 @@ You can also get the application up and running using the `mvn` command.
 * Once the application starts, you can visit the JSF client at
   * [https://localhost:9443/javaee-cafe](https://localhost:9443/javaee-cafe)
   * [http://localhost:9080/javaee-cafe](http://localhost:9080/javaee-cafe)
+* Logging in with user who doesn't belong to the admin group, you're not allowed to remove coffee as **Delete** coffee button is disabled.
+* Logging in with user who belong to the admin group, you're allowed to remove coffee as **Delete** coffee button is enabled.
 
 ## References
 * [Configuring an OpenID Connect Client in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_config_oidc_rp.html)
 * [Enabling SSL communication in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_ssl.html)
 * [Configuring authorization for applications in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_rolebased.html)
 * [SSL configuration values in Open Liberty](https://openliberty.io/docs/ref/config/#ssl.html)
-
-## Future Considerations
-* Applying JWT propagated from the inital login to secure internal REST calls.
+* [Building and consuming JSON Web Token (JWT) tokens in Liberty](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_config_jwt.html)
+* [Configuring the MicroProfile JSON Web Token](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_json.html)

--- a/javaee-cafe/pom.xml
+++ b/javaee-cafe/pom.xml
@@ -25,6 +25,7 @@
     <client.id></client.id>
     <client.secret></client.secret>
     <tenant.id></tenant.id>
+    <admin.group.id></admin.group.id>
   </properties>
   <dependencies>
     <dependency>
@@ -37,6 +38,31 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.oidc</artifactId>
+      <version>1.0.39</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.oauth</artifactId>
+      <version>1.2.39</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
+      <version>1.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile</groupId>
+      <artifactId>microprofile</artifactId>
+      <version>3.2</version>
+      <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -80,6 +106,7 @@
                     <client.id>${client.id}</client.id>
                     <client.secret>${client.secret}</client.secret>
                     <tenant.id>${tenant.id}</tenant.id>
+                    <admin.group.id>${admin.group.id}</admin.group.id>
                   </bootstrapProperties>
                 </configuration>
               </execution>

--- a/javaee-cafe/src/main/java/cafe/web/view/Cafe.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/Cafe.java
@@ -41,10 +41,10 @@ public class Cafe implements Serializable {
     private transient SecurityContext securityContext;
 
     @Inject
-    private CafeJwtUtil jwtUtil;
+    private transient CafeJwtUtil jwtUtil;
 
     @Inject
-    private CafeRequestFilter filter;
+    private transient CafeRequestFilter filter;
 
     @NotNull
     @NotEmpty

--- a/javaee-cafe/src/main/java/cafe/web/view/Cafe.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/Cafe.java
@@ -40,6 +40,12 @@ public class Cafe implements Serializable {
     @Inject
     private transient SecurityContext securityContext;
 
+    @Inject
+    private CafeJwtUtil jwtUtil;
+
+    @Inject
+    private CafeRequestFilter filter;
+
     @NotNull
     @NotEmpty
     protected String name;
@@ -71,6 +77,10 @@ public class Cafe implements Serializable {
         return securityContext.getCallerPrincipal().getName();
     }
 
+    public boolean isDisabledForDeletion() {
+        return !jwtUtil.isUserInAdminGroup();
+    }
+
     @PostConstruct
     private void init() {
         try {
@@ -87,7 +97,7 @@ public class Cafe implements Serializable {
                 public boolean verify(String hostname, SSLSession session) {
                     return true;
                 }
-            }).build().register(new CafeRequestFilter());
+            }).build().register(filter);
             this.getAllCoffees();
         } catch (IllegalArgumentException | NullPointerException | WebApplicationException | UnknownHostException ex) {
             logger.severe("Processing of HTTP response failed.");

--- a/javaee-cafe/src/main/java/cafe/web/view/CafeJwtUtil.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/CafeJwtUtil.java
@@ -1,0 +1,55 @@
+package cafe.web.view;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.ibm.websphere.security.jwt.Claims;
+import com.ibm.websphere.security.jwt.InvalidBuilderException;
+import com.ibm.websphere.security.jwt.InvalidClaimException;
+import com.ibm.websphere.security.jwt.JwtBuilder;
+import com.ibm.websphere.security.jwt.JwtException;
+import com.ibm.websphere.security.openidconnect.PropagationHelper;
+import com.ibm.websphere.security.openidconnect.token.IdToken;
+
+@SessionScoped
+public class CafeJwtUtil implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+    private String jwtTokenString;
+    private List<String> groups;
+
+    @Inject
+    @ConfigProperty(name = "admin.group.id")
+    private String ADMIN_GROUP_ID;
+
+    @SuppressWarnings("unchecked")
+    public CafeJwtUtil() {
+        try {
+            IdToken idToken = PropagationHelper.getIdToken();
+            groups = idToken.getClaim("groups") != null ? (List<String>) idToken.getClaim("groups")
+                    : Collections.emptyList();
+
+            jwtTokenString = JwtBuilder.create("jwtAuthUserBuilder").claim(Claims.SUBJECT, "javaee-cafe-rest-endpoints")
+                    .claim("upn", idToken.getClaim("preferred_username")).claim("groups", groups).buildJwt().compact();
+        } catch (JwtException | InvalidBuilderException | InvalidClaimException e) {
+            logger.severe("Creating JWT token failed.");
+            e.printStackTrace();
+        }
+    }
+
+    public String getJwtToken() {
+        return jwtTokenString;
+    }
+
+    public boolean isUserInAdminGroup() {
+        return groups.contains(ADMIN_GROUP_ID);
+    }
+}

--- a/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
@@ -1,39 +1,23 @@
 package cafe.web.view;
 
-import java.lang.invoke.MethodHandles;
-import java.util.logging.Logger;
+import java.io.Serializable;
 
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 
-import com.ibm.websphere.security.jwt.Claims;
-import com.ibm.websphere.security.jwt.InvalidBuilderException;
-import com.ibm.websphere.security.jwt.InvalidClaimException;
-import com.ibm.websphere.security.jwt.JwtBuilder;
-import com.ibm.websphere.security.jwt.JwtException;
-import com.ibm.websphere.security.openidconnect.PropagationHelper;
-import com.ibm.websphere.security.openidconnect.token.IdToken;
+@SessionScoped
+public class CafeRequestFilter implements Serializable, ClientRequestFilter {
 
-public class CafeRequestFilter implements ClientRequestFilter {
-    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
-    private String jwtTokenString;
-    
-    public CafeRequestFilter() {
-        try {
-            IdToken idToken = PropagationHelper.getIdToken();
-            jwtTokenString = JwtBuilder.create("jwtAuthUserBuilder").claim(Claims.SUBJECT, "javaee-cafe-rest-endpoints")
-                    .claim("upn", idToken.getClaim("preferred_username"))
-                    .claim("groups", idToken.getClaim("groups")).buildJwt()
-                    .compact();
-        } catch (JwtException | InvalidBuilderException | InvalidClaimException e) {
-            logger.severe("Creating JWT token failed.");
-            e.printStackTrace();
-        }
-      }
+    private static final long serialVersionUID = 1L;
 
-      @Override
-      public void filter(ClientRequestContext requestContext) {
-          requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + jwtTokenString);
-      }
+    @Inject
+    private CafeJwtUtil jwtUtil;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.getJwtToken());
+    }
 }

--- a/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
@@ -14,7 +14,7 @@ public class CafeRequestFilter implements Serializable, ClientRequestFilter {
     private static final long serialVersionUID = 1L;
 
     @Inject
-    private CafeJwtUtil jwtUtil;
+    private transient CafeJwtUtil jwtUtil;
 
     @Override
     public void filter(ClientRequestContext requestContext) {

--- a/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
+++ b/javaee-cafe/src/main/java/cafe/web/view/CafeRequestFilter.java
@@ -1,0 +1,39 @@
+package cafe.web.view;
+
+import java.lang.invoke.MethodHandles;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+import com.ibm.websphere.security.jwt.Claims;
+import com.ibm.websphere.security.jwt.InvalidBuilderException;
+import com.ibm.websphere.security.jwt.InvalidClaimException;
+import com.ibm.websphere.security.jwt.JwtBuilder;
+import com.ibm.websphere.security.jwt.JwtException;
+import com.ibm.websphere.security.openidconnect.PropagationHelper;
+import com.ibm.websphere.security.openidconnect.token.IdToken;
+
+public class CafeRequestFilter implements ClientRequestFilter {
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+    private String jwtTokenString;
+    
+    public CafeRequestFilter() {
+        try {
+            IdToken idToken = PropagationHelper.getIdToken();
+            jwtTokenString = JwtBuilder.create("jwtAuthUserBuilder").claim(Claims.SUBJECT, "javaee-cafe-rest-endpoints")
+                    .claim("upn", idToken.getClaim("preferred_username"))
+                    .claim("groups", idToken.getClaim("groups")).buildJwt()
+                    .compact();
+        } catch (JwtException | InvalidBuilderException | InvalidClaimException e) {
+            logger.severe("Creating JWT token failed.");
+            e.printStackTrace();
+        }
+      }
+
+      @Override
+      public void filter(ClientRequestContext requestContext) {
+          requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + jwtTokenString);
+      }
+}

--- a/javaee-cafe/src/main/liberty/config/server.xml
+++ b/javaee-cafe/src/main/liberty/config/server.xml
@@ -1,60 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server description="defaultServer">
 
-	<!-- Enable features -->
-	<featureManager>
-		<feature>cdi-2.0</feature>
-		<feature>jaxb-2.2</feature>
-		<feature>jpa-2.2</feature>
-		<feature>jsf-2.3</feature>
-		<feature>jaxrs-2.1</feature>
-		<feature>ejbLite-3.2</feature>
-		<feature>openidConnectClient-1.0</feature>
-		<feature>transportSecurity-1.0</feature>
-		<feature>appSecurity-3.0</feature>
-	</featureManager>
+    <!-- Enable features -->
+    <featureManager>
+        <feature>cdi-2.0</feature>
+        <feature>jaxb-2.2</feature>
+        <feature>jpa-2.2</feature>
+        <feature>jsf-2.3</feature>
+        <feature>jaxrs-2.1</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>openidConnectClient-1.0</feature>
+        <feature>transportSecurity-1.0</feature>
+        <feature>appSecurity-3.0</feature>
+        <feature>jwt-1.0</feature>
+        <feature>mpJwt-1.1</feature>
+        <feature>mpConfig-1.3</feature>
+    </featureManager>
 
-	<!-- trust JDK’s default truststore -->
-	<ssl id="defaultSSLConfig"  trustDefaultCerts="true" />
+    <!-- trust JDK’s default truststore -->
+    <ssl id="defaultSSLConfig"  trustDefaultCerts="true" />
 
-	<openidConnectClient
-		id="liberty-aad-oidc-javaeecafe" clientId="${client.id}"
-		clientSecret="${client.secret}"
-		discoveryEndpointUrl="https://login.microsoftonline.com/${tenant.id}/v2.0/.well-known/openid-configuration"
-		signatureAlgorithm="RS256"
-		userIdentityToCreateSubject="preferred_username"
-		inboundPropagation="supported" />
+    <openidConnectClient
+        id="liberty-aad-oidc-javaeecafe" clientId="${client.id}"
+        clientSecret="${client.secret}"
+        discoveryEndpointUrl="https://login.microsoftonline.com/${tenant.id}/v2.0/.well-known/openid-configuration"
+        signatureAlgorithm="RS256"
+        userIdentityToCreateSubject="preferred_username"
+        inboundPropagation="supported" />
+    
+    <!-- JWT builder -->
+    <jwtBuilder id="jwtAuthUserBuilder" keyAlias="default" issuer="https://example.com" expiresInSeconds="600" />
 
-	<httpEndpoint id="defaultHttpEndpoint" host="*"
-		httpPort="9080" httpsPort="9443" />
+    <!-- JWT consumer -->
+    <mpJwt id="jwtUserConsumer" keyName="default" issuer="https://example.com" authFilterRef="mpJwtAuthFilter" />
 
-	<!-- Automatically expand WAR files and EAR files -->
-	<applicationManager autoExpand="true" />
+    <!-- JWT auth filter -->
+    <authFilter id="mpJwtAuthFilter">
+        <requestUrl id="myRequestUrl" urlPattern="/rest" matchType="contains"/>
+    </authFilter>
 
-	<dataSource id="JavaEECafeDB"
-		jdbcDriverRef="postgresql-driver" jndiName="jdbc/JavaEECafeDB"
-		transactional="true" type="javax.sql.ConnectionPoolDataSource">
-		<properties databaseName="postgres" portNumber="5432"
-			serverName="${postgresql.server.name}" user="${postgresql.user}"
-			password="${postgresql.password}" />
-	</dataSource>
+    <httpEndpoint id="defaultHttpEndpoint" host="*"
+        httpPort="9080" httpsPort="9443" />
 
-	<jdbcDriver id="postgresql-driver"
-		javax.sql.ConnectionPoolDataSource="org.postgresql.ds.PGConnectionPoolDataSource"
-		javax.sql.XADataSource="org.postgresql.xa.PGXADataSource"
-		libraryRef="postgresql-library" />
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true" />
 
-	<library id="postgresql-library">
-		<fileset dir="${shared.resource.dir}"
-			id="PostgreSQLFileset" includes="postgresql-42.2.4.jar" />
-	</library>
+    <dataSource id="JavaEECafeDB"
+        jdbcDriverRef="postgresql-driver" jndiName="jdbc/JavaEECafeDB"
+        transactional="true" type="javax.sql.ConnectionPoolDataSource">
+        <properties databaseName="postgres" portNumber="5432"
+            serverName="${postgresql.server.name}" user="${postgresql.user}"
+            password="${postgresql.password}" />
+    </dataSource>
 
-	<webApplication id="javaee-cafe"
-		location="${server.config.dir}/apps/javaee-cafe.war">
-		<application-bnd>
-			<security-role name="users">
-				<special-subject type="ALL_AUTHENTICATED_USERS" />
-			</security-role>
-		</application-bnd>
-	</webApplication>
+    <jdbcDriver id="postgresql-driver"
+        javax.sql.ConnectionPoolDataSource="org.postgresql.ds.PGConnectionPoolDataSource"
+        javax.sql.XADataSource="org.postgresql.xa.PGXADataSource"
+        libraryRef="postgresql-library" />
+
+    <library id="postgresql-library">
+        <fileset dir="${shared.resource.dir}"
+            id="PostgreSQLFileset" includes="postgresql-42.2.4.jar" />
+    </library>
+
+    <webApplication id="javaee-cafe"
+        location="${server.config.dir}/apps/javaee-cafe.war">
+        <application-bnd>
+            <security-role name="users">
+                <special-subject type="ALL_AUTHENTICATED_USERS" />
+            </security-role>
+        </application-bnd>
+    </webApplication>
 </server>

--- a/javaee-cafe/src/main/webapp/WEB-INF/web.xml
+++ b/javaee-cafe/src/main/webapp/WEB-INF/web.xml
@@ -38,14 +38,6 @@
     <security-role>
         <role-name>users</role-name>
     </security-role>
-
-    <!-- The REST resources are unsecured. -->
-    <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>rest</web-resource-name>
-            <url-pattern>/rest/*</url-pattern>
-        </web-resource-collection>
-    </security-constraint>
     
     <security-constraint>
         <web-resource-collection>

--- a/javaee-cafe/src/main/webapp/index.xhtml
+++ b/javaee-cafe/src/main/webapp/index.xhtml
@@ -44,7 +44,7 @@
 					<h:outputText value="#{coffee.price}" />
 				</h:column>
 				<h:column>
-					<h:commandLink value="#{messages.delete}"
+					<h:commandLink value="#{messages.delete}" disabled="#{cafe.disabledForDeletion}"
 						action="#{cafe.removeCoffee(coffee.id)}" immediate="true" />
 				</h:column>
 			</h:dataTable>


### PR DESCRIPTION
## Change summary:
- Build JWT token using `groups` claim from ID token issued by AAD;
- Create `CafeJwtUtil` to build JWT using user and group info from `IDToken` returned from AAD; 
- Create `CafeRequestFilter` to intercept outgoing HTTP request by adding `Authorization` header with value of jwt token
- Secure REST endpoints exposed by `CafeResource` with security role `users`
- Add RBAC for REST endpoint of deleting coffee, which requires user in `admin` group specified in AAD

## Other notes:
- In `server.xml > webApplication > application-bnd`, all authenticated users are granted role "users", the caller principal then is demonstrated to have role "users" when making internal rest call from `Cafe`, per testing result. As a result, the value of `groups` claim in the created JWT token haven't been converted to roles. That's why `this.jwtPrincipal.getGroups().contains(ADMIN_GROUP_ID)` is used to do role-based-access-control for REST endpoint of deleting a coffee in `CafeResource.java`